### PR TITLE
Extract table name from  multiline select statements

### DIFF
--- a/lib/nsa/collectors/active_record.rb
+++ b/lib/nsa/collectors/active_record.rb
@@ -13,6 +13,8 @@ module NSA
         [ :delete, /^\s*DELETE.+FROM\s+"?([^".\s]+)"?/im ]
       ].freeze
 
+      EMPTY_MATCH_RESULT = []
+
       def self.collect(key_prefix)
         ::ActiveSupport::Notifications.subscribe("sql.active_record") do |_, start, finish, _id, payload|
           query_type, table_name = match_query(payload[:sql])
@@ -28,7 +30,7 @@ module NSA
         MATCHERS
           .lazy
           .map { |(type, regex)|
-            match = (sql.match(regex) || [])
+            match = (sql.match(regex) || EMPTY_MATCH_RESULT)
             [ type, match[1] ]
           }
           .detect { |(_, table_name)| ! table_name.nil? }

--- a/lib/nsa/collectors/active_record.rb
+++ b/lib/nsa/collectors/active_record.rb
@@ -5,29 +5,35 @@ module NSA
     module ActiveRecord
       extend ::NSA::Statsd::Publisher
 
-      DELETE_SQL_REGEX = /^DELETE.+FROM\s+"([^"]+)"/
-      INSERT_SQL_REGEX = /^INSERT INTO\s+"([^"]+)"/
-      SELECT_SQL_REGEX = /^SELECT.+FROM\s+"([^"]+)"/
-      UPDATE_SQL_REGEX = /^UPDATE\s+"([^"]+)"/
+      # Ordered by most common query type
+      MATCHERS = [
+        [ :select, /^\s*SELECT.+?FROM\s+"?([^".\s),]+)"?/im ],
+        [ :insert, /^\s*INSERT INTO\s+"?([^".\s]+)"?/im ],
+        [ :update, /^\s*UPDATE\s+"?([^".\s]+)"?/im ],
+        [ :delete, /^\s*DELETE.+FROM\s+"?([^".\s]+)"?/im ]
+      ].freeze
 
       def self.collect(key_prefix)
         ::ActiveSupport::Notifications.subscribe("sql.active_record") do |_, start, finish, _id, payload|
-          query_type, table_name = case payload[:sql]
-                                   when DELETE_SQL_REGEX then [ :delete, $1 ]
-                                   when INSERT_SQL_REGEX then [ :insert, $1 ]
-                                   when SELECT_SQL_REGEX then [ :select, $1 ]
-                                   when UPDATE_SQL_REGEX then [ :update, $1 ]
-                                   else nil
-                                   end
-
+          query_type, table_name = match_query(payload[:sql])
           unless query_type.nil?
             stat_name = "#{key_prefix}.tables.#{table_name}.queries.#{query_type}.duration"
             duration_ms = (finish - start) * 1000
             statsd_timing(stat_name, duration_ms)
           end
         end
-
       end
+
+      def self.match_query(sql)
+        MATCHERS
+          .lazy
+          .map { |(type, regex)|
+            match = (sql.match(regex) || [])
+            [ type, match[1] ]
+          }
+          .detect { |(_, table_name)| ! table_name.nil? }
+      end
+
     end
   end
 end

--- a/test/lib/nsa/collectors/active_record_test.rb
+++ b/test/lib/nsa/collectors/active_record_test.rb
@@ -29,6 +29,24 @@ class ActiveRecordTest < ::Minitest::Test
     ::NSA::Collectors::ActiveRecord.collect("db")
   end
 
+  def test_collect_select_query_multiline
+    duration = 0.3
+    query = %q{
+      SELECT
+        "users".id,
+        "users".name
+      FROM "users"
+      INNER JOIN (
+        SELECT * FROM accounts
+      )
+    }
+    event = { :sql => query }
+    expect_subscriber(event, duration)
+
+    ::NSA::Collectors::ActiveRecord.expects(:statsd_timing).with("db.tables.users.queries.select.duration", duration * 1000)
+    ::NSA::Collectors::ActiveRecord.collect("db")
+  end
+
   def test_collect_update_query
     duration = 0.4
     event = { :sql => %q{UPDATE "users" SET "users".name = 'Joe' WHERE "users".id = 1} }


### PR DESCRIPTION
**_Caveat Emptor**_: table name extraction from queries is super naive, especially
for SELECT statements. Particularly, if you are doing a sub-select in the select
portion of the query, you _will_ get the wrong result, or at least, not the most
correct result.

Move away from using `$1` global as it worries me that we may have many
thousands of requests being handled by a small number of threads, thus
contending on a global variable. No idea if it'll be a problem, but
would rather avoid it.

Use a lazy enumeration to map/detect from the most common query type to
least common (select -> insert -> update -> delete).
