### PR TITLE
Perform our own sampling for async publishing

### DIFF
--- a/lib/nsa/statsd/async_publisher.rb
+++ b/lib/nsa/statsd/async_publisher.rb
@@ -5,33 +5,43 @@ module NSA
     module AsyncPublisher
       include ::NSA::Statsd::Publisher
 
-      def async_statsd_count(key, sample_rate = nil, &block)
+      def async_statsd_count(key, sample_rate = 1, &block)
+        return unless sample_rate == 1 || rand < sample_rate
+
         ::Concurrent::Promise.execute(&block).then do |value|
-          statsd_count(key, value, sample_rate)
+          statsd_count(key, value)
         end
       end
 
-      def async_statsd_gauge(key, sample_rate = nil, &block)
+      def async_statsd_gauge(key, sample_rate = 1, &block)
+        return unless sample_rate == 1 || rand < sample_rate
+
         ::Concurrent::Promise.execute(&block).then do |value|
-          statsd_gauge(key, value, sample_rate)
+          statsd_gauge(key, value)
         end
       end
 
-      def async_statsd_set(key, sample_rate = nil, &block)
+      def async_statsd_set(key, sample_rate = 1, &block)
+        return unless sample_rate == 1 || rand < sample_rate
+
         ::Concurrent::Promise.execute(&block).then do |value|
-          statsd_set(key, value, sample_rate)
+          statsd_set(key, value)
         end
       end
 
-      def async_statsd_time(key, sample_rate = nil, &block)
+      def async_statsd_time(key, sample_rate = 1, &block)
+        return unless sample_rate == 1 || rand < sample_rate
+
         ::Concurrent::Future.execute do
-          statsd_time(key, sample_rate, &block)
+          statsd_time(key, &block)
         end
       end
 
-      def async_statsd_timing(key, sample_rate = nil, &block)
+      def async_statsd_timing(key, sample_rate = 1, &block)
+        return unless sample_rate == 1 || rand < sample_rate
+
         ::Concurrent::Promise.execute(&block).then do |value|
-          statsd_timing(key, value, sample_rate)
+          statsd_timing(key, value)
         end
       end
 


### PR DESCRIPTION
AsyncPublisher is used to send statsd metrics that are expensive to
compute on the parent thread of the call (e.g. db queries). The
AsyncPublisher accepts a `sample_rate` and passes that through to the
statsd method call for the given stat.

For async publishing, however, this doesn't make a lot of sense. We
should instead throttle the sample rate before trying to compute the
exepensive operation.

I've taken the very simple [sampling code](https://github.com/reinh/statsd/blob/ac76971c8a18f40804e3958e48a278b1b887ab24/lib/statsd.rb#L396) from the statsd-ruby gem and
simply don't schedule the computation in all of the async methods when
the sampling fails.
