### PR TITLE
Update statsd-ruby

### DIFF
--- a/nsa.gemspec
+++ b/nsa.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", "< 6", ">= 4.2"
   spec.add_dependency "concurrent-ruby", "~> 1.0.0"
   spec.add_dependency "sidekiq", ">= 3.5.0"
-  spec.add_dependency "statsd-ruby", "~> 1.2.0"
+  spec.add_dependency "statsd-ruby", "~> 1.4.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Newer versions of statsd-ruby introduced a change in how the statsd socket is managed. 1.2.0 used a thread-local variable which would cause sockets to leak whenever a sidekiq job raised an exception.