### PR TITLE
fix incorrect sidekiq metric names

### DIFF
--- a/lib/nsa/collectors/sidekiq.rb
+++ b/lib/nsa/collectors/sidekiq.rb
@@ -25,7 +25,7 @@ module NSA
       end
 
       def call(worker, message, queue_name)
-        worker_name = worker.class.name.tr("::", ".")
+        worker_name = worker.class.name.gsub("::", ".")
 
         statsd_time(make_key(worker_name, :processing_time)) do
           yield


### PR DESCRIPTION
The metric name for Sidekiq workers currently have an empty label in them, e.g. `ActivityPub..DeliveryWorker`. This is because of the use of `tr`, which translates character by character, and is not a substring substitution. Using `gsub` fixes the problem.

Unfortunately, this does mean that dashboards are probably going to break everywhere with this change.