### PR TITLE
Support activesupport 7.0

### DIFF
--- a/nsa.gemspec
+++ b/nsa.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", "< 7", ">= 4.2"
+  spec.add_dependency "activesupport", "< 7.2", ">= 4.2"
   spec.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
   spec.add_dependency "sidekiq", ">= 3.5"
   spec.add_dependency "statsd-ruby", "~> 1.4", ">= 1.4.0"

--- a/nsa.gemspec
+++ b/nsa.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "statsd-ruby", "~> 1.4", ">= 1.4.0"
 
   spec.add_development_dependency "bundler", "~> 2.1"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "mocha", "~> 1.11"
   spec.add_development_dependency "byebug", "~> 10"

--- a/test/lib/nsa/collectors/action_controller_test.rb
+++ b/test/lib/nsa/collectors/action_controller_test.rb
@@ -12,7 +12,7 @@ class ActionControllerTest < ::Minitest::Test
               :view_runtime => 100 }
     expect_subscriber(event, duration)
 
-    ::NSA::Collectors::ActionController.expects(:statsd_timing).with("web.UsersController.index.html.total_duration", duration * 1000)
+    ::NSA::Collectors::ActionController.expects(:statsd_timing).with("web.UsersController.index.html.total_duration", in_delta(duration * 1000))
     ::NSA::Collectors::ActionController.expects(:statsd_timing).with("web.UsersController.index.html.db_time", event[:db_runtime])
     ::NSA::Collectors::ActionController.expects(:statsd_timing).with("web.UsersController.index.html.view_time", event[:view_runtime])
     ::NSA::Collectors::ActionController.expects(:statsd_increment).with("web.UsersController.index.html.status.#{event[:status]}")
@@ -29,7 +29,7 @@ class ActionControllerTest < ::Minitest::Test
               :view_runtime => 100 }
     expect_subscriber(event, duration)
 
-    ::NSA::Collectors::ActionController.expects(:statsd_timing).with("web.UsersController.index.all.total_duration", duration * 1000)
+    ::NSA::Collectors::ActionController.expects(:statsd_timing).with("web.UsersController.index.all.total_duration", in_delta(duration * 1000))
     ::NSA::Collectors::ActionController.expects(:statsd_timing).with("web.UsersController.index.all.db_time", event[:db_runtime])
     ::NSA::Collectors::ActionController.expects(:statsd_timing).with("web.UsersController.index.all.view_time", event[:view_runtime])
     ::NSA::Collectors::ActionController.expects(:statsd_increment).with("web.UsersController.index.all.status.#{event[:status]}")
@@ -46,7 +46,7 @@ class ActionControllerTest < ::Minitest::Test
               :view_runtime => 100 }
     expect_subscriber(event, duration)
 
-    ::NSA::Collectors::ActionController.expects(:statsd_timing).with("web.UsersController.index.all.total_duration", duration * 1000)
+    ::NSA::Collectors::ActionController.expects(:statsd_timing).with("web.UsersController.index.all.total_duration", in_delta(duration * 1000))
     ::NSA::Collectors::ActionController.expects(:statsd_timing).with("web.UsersController.index.all.db_time", event[:db_runtime])
     ::NSA::Collectors::ActionController.expects(:statsd_timing).with("web.UsersController.index.all.view_time", event[:view_runtime])
     ::NSA::Collectors::ActionController.expects(:statsd_increment).with("web.UsersController.index.all.status.#{event[:status]}")

--- a/test/lib/nsa/collectors/active_record_test.rb
+++ b/test/lib/nsa/collectors/active_record_test.rb
@@ -7,7 +7,7 @@ class ActiveRecordTest < ::Minitest::Test
     event = { :sql => %q{DELETE FROM "users" WHERE "users".id = 1} }
     expect_subscriber(event, duration)
 
-    ::NSA::Collectors::ActiveRecord.expects(:statsd_timing).with("db.tables.users.queries.delete.duration", duration * 1000)
+    ::NSA::Collectors::ActiveRecord.expects(:statsd_timing).with("db.tables.users.queries.delete.duration", in_delta(duration * 1000))
     ::NSA::Collectors::ActiveRecord.collect("db")
   end
 
@@ -16,7 +16,7 @@ class ActiveRecordTest < ::Minitest::Test
     event = { :sql => %q{INSERT INTO "users" ("id", "name") VALUES (1, 'Bob')} }
     expect_subscriber(event, duration)
 
-    ::NSA::Collectors::ActiveRecord.expects(:statsd_timing).with("db.tables.users.queries.insert.duration", duration * 1000)
+    ::NSA::Collectors::ActiveRecord.expects(:statsd_timing).with("db.tables.users.queries.insert.duration", in_delta(duration * 1000))
     ::NSA::Collectors::ActiveRecord.collect("db")
   end
 
@@ -25,7 +25,7 @@ class ActiveRecordTest < ::Minitest::Test
     event = { :sql => %q{SELECT "users".id, "users".name FROM "users"} }
     expect_subscriber(event, duration)
 
-    ::NSA::Collectors::ActiveRecord.expects(:statsd_timing).with("db.tables.users.queries.select.duration", duration * 1000)
+    ::NSA::Collectors::ActiveRecord.expects(:statsd_timing).with("db.tables.users.queries.select.duration", in_delta(duration * 1000))
     ::NSA::Collectors::ActiveRecord.collect("db")
   end
 
@@ -43,7 +43,7 @@ class ActiveRecordTest < ::Minitest::Test
     event = { :sql => query }
     expect_subscriber(event, duration)
 
-    ::NSA::Collectors::ActiveRecord.expects(:statsd_timing).with("db.tables.users.queries.select.duration", duration * 1000)
+    ::NSA::Collectors::ActiveRecord.expects(:statsd_timing).with("db.tables.users.queries.select.duration", in_delta(duration * 1000))
     ::NSA::Collectors::ActiveRecord.collect("db")
   end
 
@@ -52,7 +52,7 @@ class ActiveRecordTest < ::Minitest::Test
     event = { :sql => %q{UPDATE "users" SET "users".name = 'Joe' WHERE "users".id = 1} }
     expect_subscriber(event, duration)
 
-    ::NSA::Collectors::ActiveRecord.expects(:statsd_timing).with("db.tables.users.queries.update.duration", duration * 1000)
+    ::NSA::Collectors::ActiveRecord.expects(:statsd_timing).with("db.tables.users.queries.update.duration", in_delta(duration * 1000))
     ::NSA::Collectors::ActiveRecord.collect("db")
   end
 

--- a/test/lib/nsa/collectors/active_support_cache_test.rb
+++ b/test/lib/nsa/collectors/active_support_cache_test.rb
@@ -1,13 +1,12 @@
 require_relative "../../../test_helper"
 
 class ActiveSupportCacheTest < ::Minitest::Test
-
   def test_collect_cache_delete
     duration = 0.1
     event = {}
     expect_subscriber("cache_delete.active_support", event, duration)
 
-    ::NSA::Collectors::ActiveSupportCache.expects(:statsd_timing).with("cache.delete.duration", duration * 1000)
+    ::NSA::Collectors::ActiveSupportCache.expects(:statsd_timing).with("cache.delete.duration", in_delta(duration * 1000))
     ::NSA::Collectors::ActiveSupportCache.collect("cache")
   end
 
@@ -16,7 +15,7 @@ class ActiveSupportCacheTest < ::Minitest::Test
     event = {}
     expect_subscriber("cache_exist?.active_support", event, duration)
 
-    ::NSA::Collectors::ActiveSupportCache.expects(:statsd_timing).with("cache.exist?.duration", duration * 1000)
+    ::NSA::Collectors::ActiveSupportCache.expects(:statsd_timing).with("cache.exist?.duration", in_delta(duration * 1000))
     ::NSA::Collectors::ActiveSupportCache.collect("cache")
   end
 
@@ -25,7 +24,7 @@ class ActiveSupportCacheTest < ::Minitest::Test
     event = {}
     expect_subscriber("cache_fetch_hit.active_support", event, duration)
 
-    ::NSA::Collectors::ActiveSupportCache.expects(:statsd_timing).with("cache.fetch_hit.duration", duration * 1000)
+    ::NSA::Collectors::ActiveSupportCache.expects(:statsd_timing).with("cache.fetch_hit.duration", in_delta(duration * 1000))
     ::NSA::Collectors::ActiveSupportCache.collect("cache")
   end
 
@@ -34,7 +33,7 @@ class ActiveSupportCacheTest < ::Minitest::Test
     event = {}
     expect_subscriber("cache_generate.active_support", event, duration)
 
-    ::NSA::Collectors::ActiveSupportCache.expects(:statsd_timing).with("cache.generate.duration", duration * 1000)
+    ::NSA::Collectors::ActiveSupportCache.expects(:statsd_timing).with("cache.generate.duration", in_delta(duration * 1000))
     ::NSA::Collectors::ActiveSupportCache.collect("cache")
   end
 
@@ -43,7 +42,7 @@ class ActiveSupportCacheTest < ::Minitest::Test
     event = { :hit => true }
     expect_subscriber("cache_read.active_support", event, duration)
 
-    ::NSA::Collectors::ActiveSupportCache.expects(:statsd_timing).with("cache.read_hit.duration", duration * 1000)
+    ::NSA::Collectors::ActiveSupportCache.expects(:statsd_timing).with("cache.read_hit.duration", in_delta(duration * 1000))
     ::NSA::Collectors::ActiveSupportCache.collect("cache")
   end
 
@@ -52,7 +51,7 @@ class ActiveSupportCacheTest < ::Minitest::Test
     event = { :hit => false }
     expect_subscriber("cache_read.active_support", event, duration)
 
-    ::NSA::Collectors::ActiveSupportCache.expects(:statsd_timing).with("cache.read_miss.duration", duration * 1000)
+    ::NSA::Collectors::ActiveSupportCache.expects(:statsd_timing).with("cache.read_miss.duration", in_delta(duration * 1000))
     ::NSA::Collectors::ActiveSupportCache.collect("cache")
   end
 
@@ -61,7 +60,7 @@ class ActiveSupportCacheTest < ::Minitest::Test
     event = {}
     expect_subscriber("cache_write.active_support", event, duration)
 
-    ::NSA::Collectors::ActiveSupportCache.expects(:statsd_timing).with("cache.write.duration", duration * 1000)
+    ::NSA::Collectors::ActiveSupportCache.expects(:statsd_timing).with("cache.write.duration", in_delta(duration * 1000))
     ::NSA::Collectors::ActiveSupportCache.collect("cache")
   end
 
@@ -70,7 +69,7 @@ class ActiveSupportCacheTest < ::Minitest::Test
     event = {}
     expect_subscriber("cache_some_other_key.active_support", event, duration)
 
-    ::NSA::Collectors::ActiveSupportCache.expects(:statsd_timing).with("cache.some_other_key.duration", duration * 1000)
+    ::NSA::Collectors::ActiveSupportCache.expects(:statsd_timing).with("cache.some_other_key.duration", in_delta(duration * 1000))
     ::NSA::Collectors::ActiveSupportCache.collect("cache")
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,3 +7,25 @@ require "minitest/unit"
 require "mocha/minitest"
 
 require "minitest/autorun"
+
+module Mocha::ParameterMatchers
+  class InDelta < Mocha::ParameterMatchers::Base
+    def initialize(value, delta=0.001)
+      @value, @delta = value, delta
+      @range = (-@delta...@delta)
+    end
+
+    def matches?(available_parameters)
+      parameter = available_parameters.shift
+      @range.cover?(parameter - @value)
+    end
+
+    def mocha_inspect
+      "in_delta(#{@value.mocha_inspect}, #{@delta.mocha_inspect})"
+    end
+  end
+
+  def in_delta(*args)
+    InDelta.new(*args)
+  end
+end


### PR DESCRIPTION
Updates the activesupport dependency to include Rails 7.0. I also allowed 7.1, which is not yet released, but the current main branch is compatible and our version policy is to not break public APIs without a deprecation cycle.

This also makes the test suite more reliable, and work on Ruby 3.2
