### PR TITLE
Support activesupport 7.2

### DIFF
--- a/nsa.gemspec
+++ b/nsa.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", "< 7.2", ">= 4.2"
+  spec.add_dependency "activesupport", "<= 7.2", ">= 4.2"
   spec.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
   spec.add_dependency "sidekiq", ">= 3.5"
   spec.add_dependency "statsd-ruby", "~> 1.4", ">= 1.4.0"


### PR DESCRIPTION
Hello, Rails 7.2 has recently been released.
https://rubyonrails.org/2024/8/10/Rails-7-2-0-has-been-released

With that, a new version of ActiveSupport has been released, so we are upgrading the version to work with 7.2 as well.